### PR TITLE
Handle bad result when listing files in a zip archive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,8 @@ pub type Result<T = ()> = std::result::Result<T, Error>;
 
 impl From<zip::result::ZipError> for Error {
     fn from(e: zip::result::ZipError) -> Error {
-        let errstr = {
-            use std::error::Error;
-            format!("Zip error: {}", e.description())
-        };
+        let errstr = format!("Zip error: {}", e);
+
         Error::VfsError(errstr)
     }
 }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -619,14 +619,6 @@ impl ZipFS {
             .collect::<Vec<String>>();
         */
 
-        // Or partition good/bad results...
-        /*
-        let (idx, _errs): (Vec<_>, Vec<_>) = items.partition(std::result::Result::is_ok);
-
-        let idx = idx.into_iter().map(Result::unwrap).collect();
-        let _errs: Vec<_> = _errs.into_iter().map(Result::unwrap_err).collect();
-        */
-
         Ok(Self {
             source,
             archive: RefCell::new(archive),

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -602,15 +602,31 @@ impl ZipFS {
         mut archive: Box<dyn ZipArchiveAccess>,
         source: Option<PathBuf>,
     ) -> Result<Self> {
-        let idx = (0..archive.len())
-            .map(|i| {
-                archive
-                    .by_index(i)
-                    .expect("Should never happen!")
-                    .name()
-                    .to_string()
-            })
-            .collect();
+        let items = (0..archive.len()).map(|i| {
+            archive
+                .by_index(i)
+                .map_err(|err| Error::from(err))
+                .and_then(|item| Ok(item.name().to_string()))
+        });
+
+        // Propagate first bad result...
+        let idx = items.collect::<Result<Vec<_>>>()?;
+
+        // Or ignore bad results entirely...
+        /*
+        let idx = items
+            .filter_map(Result::ok)
+            .collect::<Vec<String>>();
+        */
+
+        // Or partition good/bad results...
+        /*
+        let (idx, _errs): (Vec<_>, Vec<_>) = items.partition(std::result::Result::is_ok);
+
+        let idx = idx.into_iter().map(Result::unwrap).collect();
+        let _errs: Vec<_> = _errs.into_iter().map(Result::unwrap_err).collect();
+        */
+
         Ok(Self {
             source,
             archive: RefCell::new(archive),

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -605,8 +605,8 @@ impl ZipFS {
         let items = (0..archive.len()).map(|i| {
             archive
                 .by_index(i)
-                .map_err(|err| Error::from(err))
-                .and_then(|item| Ok(item.name().to_string()))
+                .map_err(Error::from)
+                .map(|item| item.name().to_string())
         });
 
         // Propagate first bad result...


### PR DESCRIPTION
Fixes #2. Removes expect/unwrap and instead converts the encountered `ZipError` to a `gvfs::Error`.